### PR TITLE
only run detailed patch control if patches are available

### DIFF
--- a/controls/patches.rb
+++ b/controls/patches.rb
@@ -23,4 +23,5 @@ control 'patches' do
       its('version') { should eq update['version'] }
     end
   }
+  only_if { linux_update.updates.length > 0 }
 end


### PR DESCRIPTION
This allows InSpec to display that the control has not been executed because no patches are available.