### PR TITLE
allow yum to run as non-root user.

### DIFF
--- a/libraries/linux_updates.rb
+++ b/libraries/linux_updates.rb
@@ -199,7 +199,7 @@ PRINT_JSON
   def updates
     rhel_updates = <<-PRINT_JSON
 #!/bin/sh
-python -c 'import sys; sys.path.insert(0, "/usr/share/yum-cli"); import cli; list = cli.YumBaseCli().returnPkgLists(["updates"]);res = ["{\\"name\\":\\""+x.name+"\\", \\"version\\":\\""+x.version+"-"+x.release+"\\",\\"arch\\":\\""+x.arch+"\\",\\"repository\\":\\""+x.repo.id+"\\"}" for x in list.updates]; print "{\\"available\\":["+",".join(res)+"]}"'
+sudo python -c 'import sys; sys.path.insert(0, "/usr/share/yum-cli"); import cli; list = cli.YumBaseCli().returnPkgLists(["updates"]);res = ["{\\"name\\":\\""+x.name+"\\", \\"version\\":\\""+x.version+"-"+x.release+"\\",\\"arch\\":\\""+x.arch+"\\",\\"repository\\":\\""+x.repo.id+"\\"}" for x in list.updates]; print "{\\"available\\":["+",".join(res)+"]}"'
 PRINT_JSON
     cmd = @inspec.bash(rhel_updates)
     unless cmd.exit_status == 0

--- a/libraries/linux_updates.rb
+++ b/libraries/linux_updates.rb
@@ -199,7 +199,7 @@ PRINT_JSON
   def updates
     rhel_updates = <<-PRINT_JSON
 #!/bin/sh
-sudo python -c 'import sys; sys.path.insert(0, "/usr/share/yum-cli"); import cli; ybc = cli.YumBaseCli(); ybc.setCacheDir("/tmp"); list = ybc.returnPkgLists(["updates"]);res = ["{\\"name\\":\\""+x.name+"\\", \\"version\\":\\""+x.version+"-"+x.release+"\\",\\"arch\\":\\""+x.arch+"\\",\\"repository\\":\\""+x.repo.id+"\\"}" for x in list.updates]; print "{\\"available\\":["+",".join(res)+"]}"'
+python -c 'import sys; sys.path.insert(0, "/usr/share/yum-cli"); import cli; ybc = cli.YumBaseCli(); ybc.setCacheDir("/tmp"); list = ybc.returnPkgLists(["updates"]);res = ["{\\"name\\":\\""+x.name+"\\", \\"version\\":\\""+x.version+"-"+x.release+"\\",\\"arch\\":\\""+x.arch+"\\",\\"repository\\":\\""+x.repo.id+"\\"}" for x in list.updates]; print "{\\"available\\":["+",".join(res)+"]}"'
 PRINT_JSON
     cmd = @inspec.bash(rhel_updates)
     unless cmd.exit_status == 0

--- a/libraries/linux_updates.rb
+++ b/libraries/linux_updates.rb
@@ -199,7 +199,7 @@ PRINT_JSON
   def updates
     rhel_updates = <<-PRINT_JSON
 #!/bin/sh
-sudo python -c 'import sys; sys.path.insert(0, "/usr/share/yum-cli"); import cli; list = cli.YumBaseCli().returnPkgLists(["updates"]);res = ["{\\"name\\":\\""+x.name+"\\", \\"version\\":\\""+x.version+"-"+x.release+"\\",\\"arch\\":\\""+x.arch+"\\",\\"repository\\":\\""+x.repo.id+"\\"}" for x in list.updates]; print "{\\"available\\":["+",".join(res)+"]}"'
+sudo python -c 'import sys; sys.path.insert(0, "/usr/share/yum-cli"); import cli; ybc = cli.YumBaseCli(); ybc.setCacheDir("/tmp"); list = ybc.returnPkgLists(["updates"]);res = ["{\\"name\\":\\""+x.name+"\\", \\"version\\":\\""+x.version+"-"+x.release+"\\",\\"arch\\":\\""+x.arch+"\\",\\"repository\\":\\""+x.repo.id+"\\"}" for x in list.updates]; print "{\\"available\\":["+",".join(res)+"]}"'
 PRINT_JSON
     cmd = @inspec.bash(rhel_updates)
     unless cmd.exit_status == 0


### PR DESCRIPTION
fixes #19 
by default yum-cli uses the cache dir "/var/cache/yum/". This dir owned by root. This means this test fails when run as non-root user. 
My assumption is that this test can use a different cache dir without problems.
I have added `setCacheDir("/tmp")` 
I tested on centos and amazon linux and it seemed to work.
could test with
inspec exec https://github.com/iveskins/linux-patch-baseline -t ssh://notroot@yourhost -i ~/secret_and_things