### PR TITLE
Bump version to 0.5.0 and switch to inspec 3 for check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+Gemfile.lock
+inspec.lock

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -44,9 +44,9 @@ Style/PercentLiteralDelimiters:
     '%w': '{}'
     '%W': ()
     '%x': ()
-Style/AlignHash:
+Layout/AlignHash:
   Enabled: false
-Style/PredicateName:
+Naming/PredicateName:
   Enabled: false
 Style/ZeroLengthPredicate:
   Enabled: false
@@ -62,7 +62,7 @@ Style/AndOr:
   Enabled: false
 Style/Not:
   Enabled: false
-Style/FileName:
+Naming/FileName:
   Enabled: false
 Style/TrailingCommaInHashLiteral:
   EnforcedStyleForMultiline: comma
@@ -76,7 +76,9 @@ Style/UnlessElse:
   Enabled: false
 BlockDelimiters:
   Enabled: false
-Style/SpaceAroundOperators:
+Layout/SpaceAroundOperators:
   Enabled: false
 Style/IfUnlessModifier:
+  Enabled: false
+Style/StderrPuts:
   Enabled: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Change Log
 
+## [0.5.0](https://github.com/dev-sec/linux-patch-baseline/tree/0.5.0) (2019-05-14)
+[Full Changelog](https://github.com/dev-sec/linux-patch-baseline/compare/0.4.0...0.5.0)
+
+**Closed issues:**
+
+- Redhat update check only works if user has root access. [\#19](https://github.com/dev-sec/linux-patch-baseline/issues/19)
+
+**Merged pull requests:**
+
+- Update issue templates [\#21](https://github.com/dev-sec/linux-patch-baseline/pull/21) ([rndmh3ro](https://github.com/rndmh3ro))
+- allow yum to run as non-root user. [\#20](https://github.com/dev-sec/linux-patch-baseline/pull/20) ([iveskins](https://github.com/iveskins))
+- small typo in the packages method [\#18](https://github.com/dev-sec/linux-patch-baseline/pull/18) ([aaronlippold](https://github.com/aaronlippold))
+- fix \#3 [\#4](https://github.com/dev-sec/linux-patch-baseline/pull/4) ([chris-rock](https://github.com/chris-rock))
+
 ## [0.4.0](https://github.com/dev-sec/linux-patch-baseline/tree/0.4.0) (2018-04-12)
 [Full Changelog](https://github.com/dev-sec/linux-patch-baseline/compare/0.3.0...0.4.0)
 
@@ -36,7 +50,6 @@
 
 **Merged pull requests:**
 
-- fix \#3 [\#4](https://github.com/dev-sec/linux-patch-baseline/pull/4) ([chris-rock](https://github.com/chris-rock))
 - add basic test-kitchen config [\#1](https://github.com/dev-sec/linux-patch-baseline/pull/1) ([chris-rock](https://github.com/chris-rock))
 
 ## [0.1.0](https://github.com/dev-sec/linux-patch-baseline/tree/0.1.0) (2016-09-27)

--- a/Gemfile
+++ b/Gemfile
@@ -1,10 +1,12 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 
-gem 'rake'
-gem 'rack', '1.6.4'
-gem 'inspec', '~> 1'
-gem 'highline', '~> 1.6.0'
-gem 'rubocop', '~>0.54.0'
+gem 'rake', '~> 12.3.2'
+gem 'rack', '~> 2.0.7'
+gem 'inspec', '~> 3'
+gem 'highline', '~> 2.0.2'
+gem 'rubocop', '~> 0.68.1'
 
 group :integration do
   gem 'berkshelf'
@@ -14,5 +16,6 @@ group :integration do
 end
 
 group :tools do
-  gem 'github_changelog_generator', '~> 1.12.0'
+  gem 'github_changelog_generator', '~> 1.14.3'
+  gem 'pry-coolline', '~> 0.2.5'
 end

--- a/Rakefile
+++ b/Rakefile
@@ -20,23 +20,30 @@ task default: [:lint, 'test:check']
 namespace :test do
   # run inspec check to verify that the profile is properly configured
   task :check do
-    dir = File.join(File.dirname(__FILE__))
-    sh("bundle exec inspec check #{dir}")
+    require 'inspec'
+    puts "Checking profile with InSpec Version: #{Inspec::VERSION}"
+    profile = Inspec::Profile.for_target('.', backend: Inspec::Backend.create(Inspec::Config.mock))
+    pp profile.check
   end
 end
 
-# Automatically generate a changelog for this project. Only loaded if
-# the necessary gem is installed. By default its picking up the version from
-# inspec.yml. You can override that behavior with `rake changelog to=1.2.0`
-begin
-  require 'yaml'
-  metadata = YAML.load_file('inspec.yml')
-  v = ENV['to'] || metadata['version']
-  puts "Generate changelog for version #{v}"
-  require 'github_changelog_generator/task'
-  GitHubChangelogGenerator::RakeTask.new :changelog do |config|
-    config.future_release = v
+task :changelog do
+  # Automatically generate a changelog for this project. Only loaded if
+  # the necessary gem is installed. By default its picking up the version from
+  # inspec.yml. You can override that behavior with `rake changelog to=1.2.0`
+  begin
+    require 'yaml'
+    metadata = YAML.load_file('inspec.yml')
+    v = ENV['to'] || metadata['version']
+    puts " * Generating changelog for version #{v}"
+    require 'github_changelog_generator/task'
+    GitHubChangelogGenerator::RakeTask.new :changelog do |config|
+      config.future_release = v
+      config.user = 'dev-sec'
+      config.project = 'linux-patch-baseline'
+    end
+    Rake::Task[:changelog].execute
+  rescue LoadError
+    puts '>>>>> GitHub Changelog Generator not loaded, omitting tasks'
   end
-rescue LoadError
-  puts '>>>>> GitHub Changelog Generator not loaded, omitting tasks'
 end

--- a/inspec.yml
+++ b/inspec.yml
@@ -1,7 +1,7 @@
 name: linux-patch-baseline
 title: DevSec Linux Patch Benchmark
 summary: Verifies that all patches have been applied
-version: 0.4.0
+version: 0.5.0
 
 maintainer: Christoph Hartmann
 copyright: Christoph Hartmann

--- a/libraries/linux_updates.rb
+++ b/libraries/linux_updates.rb
@@ -38,29 +38,37 @@ class LinuxUpdateManager < Inspec.resource(1)
 
   def updates
     return [] if @update_mgmt.nil?
+
     u = @update_mgmt.updates
     return [] if u.nil? || u.empty?
+
     u['available']
   end
 
   def uptodate?
     return nil if @update_mgmt.nil?
+
     u = @update_mgmt.updates
     return false if u.nil? || !u['available'].empty?
+
     l = @update_mgmt.patches
     return false if l.nil? || !l.empty?
+
     true
   end
 
   def packages
     return [] if @update_mgmt.nil?
+
     p = @update_mgmt.packages
     return [] if p.nil? || p.empty?
+
     p['installed']
   end
 
   def patches
     return [] if @update_mgmt.nil?
+
     @update_mgmt.patches || []
   end
 
@@ -156,7 +164,7 @@ dpkg-query -W -f='${Status}\\t${Package}\\t${Version}\\t${Architecture}\\n' |\\
   grep '^install ok installed\\s' |\\
   awk '{ printf "{\\"name\\":\\""$4"\\",\\"version\\":\\""$5"\\",\\"arch\\":\\""$6"\\"}," }' | rev | cut -c 2- | rev | tr -d '\\n'
 echo -n ']}'
-PRINT_JSON
+    PRINT_JSON
     parse_json(ubuntu_packages)
   end
 
@@ -166,7 +174,7 @@ echo -n '{"available":['
 DEBIAN_FRONTEND=noninteractive apt-get upgrade --dry-run | grep Inst | tr -d '[]()' |\\
   awk '{ printf "{\\"name\\":\\""$2"\\",\\"version\\":\\""$4"\\",\\"repo\\":\\""$5"\\",\\"arch\\":\\""$6"\\"}," }' | rev | cut -c 2- | rev | tr -d '\\n'
 echo -n ']}'
-PRINT_JSON
+    PRINT_JSON
     parse_json(ubuntu_updates)
   end
 
@@ -179,7 +187,7 @@ DEBIAN_FRONTEND=noninteractive apt-get update >/dev/null 2>&1
 readlock() { cat /proc/locks | awk '{print $5}' | grep -v ^0 | xargs -I {1} find /proc/{1}/fd -maxdepth 1 -exec readlink {} \\; | grep '^/var/lib/dpkg/lock$'; }
 while test -n "$(readlock)"; do sleep 1; done
 echo " "
-PRINT_JSON
+    PRINT_JSON
     base
   end
 end
@@ -192,7 +200,7 @@ echo -n '{"installed":['
 rpm -qa --queryformat '"name":"%{NAME}","version":"%{VERSION}-%{RELEASE}","arch":"%{ARCH}"\\n' |\\
   awk '{ printf "{"$1"}," }' | rev | cut -c 2- | rev | tr -d '\\n'
 echo -n ']}'
-PRINT_JSON
+    PRINT_JSON
     parse_json(rhel_packages)
   end
 
@@ -200,7 +208,7 @@ PRINT_JSON
     rhel_updates = <<-PRINT_JSON
 #!/bin/sh
 python -c 'import sys; sys.path.insert(0, "/usr/share/yum-cli"); import cli; ybc = cli.YumBaseCli(); ybc.setCacheDir("/tmp"); list = ybc.returnPkgLists(["updates"]);res = ["{\\"name\\":\\""+x.name+"\\", \\"version\\":\\""+x.version+"-"+x.release+"\\",\\"arch\\":\\""+x.arch+"\\",\\"repository\\":\\""+x.repo.id+"\\"}" for x in list.updates]; print "{\\"available\\":["+",".join(res)+"]}"'
-PRINT_JSON
+    PRINT_JSON
     cmd = @inspec.bash(rhel_updates)
     unless cmd.exit_status == 0
       # essentially we want https://github.com/chef/inspec/issues/1205


### PR DESCRIPTION
Switched to inspec check without CLI, this will allow checking the profile with inspec 4 without having to auto accept the license.

I updated the Rakefile to only load the changelog task when it is targetted.

I had to specify the repo user and project in the config of the changelog task, otherwise, I was getting this exception:
```
Octokit::InvalidRepository: "/" is invalid as a repository identifier. Use the user/repo (String) format
```