### PR TITLE
Updated to use a while loop for releasing "apt update" lock

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ This [InSpec](http://inspec.io/) profile verifies that all updates have been ins
 
 - RHEL 6/7
 - CentOS 6/7
+- Debian 8/9/10
 - Ubuntu 12.04+
 - OpenSUSE, SuSE 11/12
 


### PR DESCRIPTION
The previous implementation waited for the lock to release, this
version retries until a successful exit. The 'ubuntu' names were
replaced with 'debian' to reflect the correct origins.

This fixes https://github.com/dev-sec/linux-patch-baseline/issues/22 
Tested with Debian 8/9/10, Ubuntu 16.04/18.04/20.04, and Raspbian 10.

Signed-off-by: Matt Ray <github@mattray.dev>