### PR TITLE
checkout before creating the release draft

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,6 +54,8 @@ jobs:
           name: dev-sec CI
           email: hello@dev-sec.io
 
+      - uses: actions/checkout@v1
+
       - name: Read CHANGELOG.md
         id: package
         uses: juliangruber/read-file-action@v1


### PR DESCRIPTION
It seems that the github action to do a release didn't checkout the commit created with the new version and changelog.

This PR tries to remediate to that.